### PR TITLE
Update ROS2 installation guide

### DIFF
--- a/jetson-setup.md
+++ b/jetson-setup.md
@@ -69,9 +69,9 @@ Dev tools
 sudo apt install ros-dev-tools
 ```
 
-Set up the environment
+Add sourcing to shell startup script
 ```
-source /opt/ros/humble/setup.bash
+echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
 ```
 
 ## isaac_ros


### PR DESCRIPTION
Added ´echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc´ to installation guide, so you don't need to source setup script manually every time you open a new shell.