### PR TITLE
Add WIP Docker-based simulation setup instructions and update Dockerfile

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,12 @@
 [submodule "ros2_ws/src/simulation/PX4-Autopilot"]
 	path = ros2_ws/src/simulation/PX4-Autopilot
-	url = https://github.com/PX4/PX4-Autopilot.git
+	url = https://github.com/CatScanners/PX4-Autopilot.git
 [submodule "ros2_ws/src/simulation/Micro-XRCE-DDS-Agent"]
 	path = ros2_ws/src/simulation/Micro-XRCE-DDS-Agent
 	url = https://github.com/eProsima/Micro-XRCE-DDS-Agent.git
 [submodule "ros2_ws/src/simulation/ws_offboard_control/src/px4_msgs"]
 	path = ros2_ws/src/simulation/ws_offboard_control/src/px4_msgs
 	url = https://github.com/PX4/px4_msgs.git
-[submodule "ros2_ws/src/simulation/px4_ros_com"]
-	path = ros2_ws/src/simulation/px4_ros_com
-	url = https://github.com/CatScanners/px4_ros_com.git
 [submodule "ros2_ws/src/simulation/ws_offboard_control/src/px4_ros_com"]
 	path = ros2_ws/src/simulation/ws_offboard_control/src/px4_ros_com
 	url = https://github.com/CatScanners/px4_ros_com.git

--- a/ros2_ws/src/simulation/Docker-sim-instructions.md
+++ b/ros2_ws/src/simulation/Docker-sim-instructions.md
@@ -1,0 +1,102 @@
+# Docker simulation setup guide
+
+This guide walks you through setting up the **ROS 2 + Gazebo + PX4 simulation** environment inside Docker using the `find-my-kitten` repository.
+
+---
+
+## Prerequisites
+
+- **Docker must be preinstalled**
+- Make sure that there is an access to Docker (or use `sudo`)
+- Clone the repository using:
+
+```bash
+git clone --recursive git@github.com:CatScanners/find-my-kitten.git
+```
+
+---
+
+## Build and run the Docker container
+
+1. **Navigate to the simulation directory**:
+
+   ```bash
+   cd find-my-kitten/ros2_ws/src/simulation
+   ```
+
+2. **Build the Docker container**:
+
+   ```bash
+   sudo docker build -t kitten-sim .
+   ```
+
+3. **Run the container**:
+
+   ```bash
+   sudo docker run -it \
+     --privileged \
+     --device /dev/fuse \
+     --cap-add SYS_ADMIN \
+     -e DISPLAY=$DISPLAY \
+     -v /tmp/.X11-unix:/tmp/.X11-unix \
+     kitten-sim
+   ```
+
+---
+
+## Use `tmux` for Multiple Terminal Panes
+
+4. **Start `tmux` inside the container**:
+
+   ```bash
+   tmux
+   ```
+
+5. **Useful `tmux` shortcuts**:
+
+| Action                        | Shortcut              |
+|------------------------------|-----------------------|
+| Split pane vertically        | `Ctrl + b`, then `%`  |
+| Split pane horizontally      | `Ctrl + b`, then `"`  |
+| Close current pane           | `Ctrl + b`, then `x`  |
+| Switch between panes         | `Ctrl + b`, then arrow keys |
+
+> **After opening each new pane, run:**
+
+```bash
+source /opt/ros/humble/setup.bash
+```
+
+---
+
+## Start the simulation components
+
+6. **In the first pane**, launch QGroundControl:
+
+```bash
+./QGroundControl.AppImage
+```
+
+7. **In another pane**, start the ROS-Gazebo image bridge:
+
+```bash
+ros2 run ros_gz_image image_bridge /camera
+```
+
+8. **In another pane**, run the DDS Agent:
+
+```bash
+cd find-my-kitten/ros2_ws/src/simulation/Micro-XRCE-DDS-Agent/build/
+MicroXRCEAgent udp4 -p 8888
+```
+
+9. **In another pane**, launch the PX4 simulation:
+
+```bash
+cd find-my-kitten/ros2_ws/src/simulation/PX4-Autopilot
+make px4_sitl gz_x500_mono_cam_lawn
+```
+
+**QGroundControl** should automatically connect to the PX4 simulation.
+Just open the application window if it isn't already visible.
+

--- a/ros2_ws/src/simulation/Docker-sim-instructions.md
+++ b/ros2_ws/src/simulation/Docker-sim-instructions.md
@@ -43,7 +43,14 @@ git clone --recursive git@github.com:CatScanners/find-my-kitten.git
    ```
 
 ---
+## Either use startsim.sh file to start the simulation or start the simulation manually.
+## First approach:
+4. **Start simulation**:
+   ```bash
+   ./startsim.sh
+   ```
 
+## Second approach:
 ## Use `tmux` for Multiple Terminal Panes
 
 4. **Start `tmux` inside the container**:

--- a/ros2_ws/src/simulation/Dockerfile
+++ b/ros2_ws/src/simulation/Dockerfile
@@ -47,7 +47,7 @@ RUN /bin/bash -c "source ~/.bashrc"
 
 #### IMPORTANT UNCOMMENT THIS ONCE EVERYTHING IS READY.
 #### RUN git clone https://github.com/CatScanners/find-my-kitten.git
-RUN git clone --branch kaius --single-branch --recursive https://github.com/CatScanners/find-my-kitten.git
+RUN git clone --branch add-instructions --single-branch --recursive https://github.com/CatScanners/find-my-kitten.git
 WORKDIR /find-my-kitten/ros2_ws/src/simulation
 
 RUN git submodule update --init --recursive
@@ -103,5 +103,9 @@ RUN sudo apt install -y \
 	 libpulse-dev
 RUN sudo wget https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl.AppImage
 RUN sudo chmod +x ./QGroundControl.AppImage
+
+# Bash script for simulation setup (opens and runs all necessary scripts)
+COPY startsim.sh /find-my-kitten/startsim.sh
+RUN sudo chmod +x /find-my-kitten/startsim.sh
 
 CMD ["/bin/bash"]

--- a/ros2_ws/src/simulation/Dockerfile
+++ b/ros2_ws/src/simulation/Dockerfile
@@ -77,6 +77,9 @@ RUN echo "source find-my-kitten/ros2_ws/src/simulation/ws_offboard_control/insta
 # Install ROS 2 Gazebo bridge (ros_gz) for image transport between Gazebo and ROS 2
 RUN sudo apt-get install -y ros-humble-ros-gzharmonic
 
+# Install tmux
+RUN apt install -y tmux
+
 # Install QGroundControl
 WORKDIR /find-my-kitten
 RUN useradd -ms /bin/bash user && \

--- a/ros2_ws/src/simulation/Dockerfile
+++ b/ros2_ws/src/simulation/Dockerfile
@@ -45,7 +45,9 @@ RUN sudo apt-get update && sudo apt-get install -y \
 RUN echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
 RUN /bin/bash -c "source ~/.bashrc"
 
-RUN git clone https://github.com/CatScanners/find-my-kitten.git
+#### IMPORTANT UNCOMMENT THIS ONCE EVERYTHING IS READY.
+#### RUN git clone https://github.com/CatScanners/find-my-kitten.git
+RUN git clone --branch kaius --single-branch --recursive https://github.com/CatScanners/find-my-kitten.git
 WORKDIR /find-my-kitten/ros2_ws/src/simulation
 
 RUN git submodule update --init --recursive

--- a/ros2_ws/src/simulation/Dockerfile
+++ b/ros2_ws/src/simulation/Dockerfile
@@ -74,6 +74,9 @@ WORKDIR /find-my-kitten/ros2_ws/src/simulation/ws_offboard_control/
 RUN bash -c "source /opt/ros/humble/setup.bash && colcon build"
 RUN echo "source find-my-kitten/ros2_ws/src/simulation/ws_offboard_control/install/local_setup.bash" >> ~/.bashrc
 
+# Install ROS 2 Gazebo bridge (ros_gz) for image transport between Gazebo and ROS 2
+RUN sudo apt-get install -y ros-humble-ros-gzharmonic
+
 # Install QGroundControl
 WORKDIR /find-my-kitten
 RUN useradd -ms /bin/bash user && \

--- a/ros2_ws/src/simulation/startsim.sh
+++ b/ros2_ws/src/simulation/startsim.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Start a tmux session named 'sim'
+tmux new-session -d -s sim
+
+# Pane 0: QGroundControl
+tmux send-keys -t sim:0 'cd /find-my-kitten && ./QGroundControl.AppImage' C-m
+
+# Pane 1: ROS-GZ image bridge
+tmux split-window -h -t sim
+tmux send-keys -t sim:0.1 'source /opt/ros/humble/setup.bash && ros2 run ros_gz_image image_bridge /camera' C-m
+
+# Pane 2: MicroXRCEAgent
+tmux split-window -v -t sim:0.1
+tmux send-keys -t sim:0.2 'cd /find-my-kitten/ros2_ws/src/simulation/Micro-XRCE-DDS-Agent/build/ && MicroXRCEAgent udp4 -p 8888' C-m
+
+# Pane 3: PX4 simulation
+tmux select-pane -t sim:0.0
+tmux split-window -v
+tmux send-keys -t sim 'cd /find-my-kitten/ros2_ws/src/simulation/PX4-Autopilot && make px4_sitl gz_x500_gimbal_baylands' C-m
+
+# Attach to the session
+tmux select-pane -t sim:0.0
+tmux attach-session -t sim


### PR DESCRIPTION
- Create file Docker-sim-instructions.md for instructions.
- Add tmux to Dockerfile.
- Add ros2-gz-bridge to Dockerfile for image transmission between Gazebo and Ros2.
- Create simulation startup script.

Steps for simulation setup are shown [here](https://drive.google.com/file/d/1mNUFZUJYmGo_Ks2IZz0ZsXVkUSGddD1h/view?usp=sharing).
